### PR TITLE
REG-17188 add magic changed tracker

### DIFF
--- a/lib/has_magic_columns/extend.rb
+++ b/lib/has_magic_columns/extend.rb
@@ -41,7 +41,7 @@ module HasMagicColumns
 
     module InstanceMethods
       def magic_column_names
-        magic_columns.pluck(:name)
+        magic_columns.map(&:name)
       end
 
       def magic_changes

--- a/lib/has_magic_columns/extend.rb
+++ b/lib/has_magic_columns/extend.rb
@@ -88,7 +88,7 @@ module HasMagicColumns
           attribute.map { |attr| column.type_cast(attr.value) }
         else
           value = (attr = attribute.first) ? attr.to_s : column.default
-          value.nil?  ? nil : column.type_cast(value)
+          value.nil? ? nil : column.type_cast(value)
         end
       end
 
@@ -100,7 +100,7 @@ module HasMagicColumns
         if method_name =~ /=$/
           var_name = method_name.gsub('=', '')
           value = args.first
-          write_magic_attribute(var_name,value)
+          write_magic_attribute(var_name, value)
         else
           read_attribute_with_magic(method_name)
         end

--- a/lib/has_magic_columns/extend.rb
+++ b/lib/has_magic_columns/extend.rb
@@ -9,8 +9,8 @@ module HasMagicColumns
       def has_magic_columns(options = {})
         unless magical?
           # Associations
-          has_many :magic_attribute_relationships, :as => :owner, :dependent => :destroy
-          has_many :magic_attributes, :through => :magic_attribute_relationships, :dependent => :destroy
+          has_many :magic_attribute_relationships, as: :owner, dependent: :destroy
+          has_many :magic_attributes, through: :magic_attribute_relationships, dependent: :destroy
 
           # Inheritence
           cattr_accessor :inherited_from
@@ -27,8 +27,8 @@ module HasMagicColumns
 
           # otherwise the calling model has the relationships
           else
-            has_many :magic_column_relationships, :as => :owner, :dependent => :destroy
-            has_many :magic_columns, :through => :magic_column_relationships, :dependent => :destroy
+            has_many :magic_column_relationships, as: :owner, dependent: :destroy
+            has_many :magic_columns, through: :magic_column_relationships, dependent: :destroy
           end
         end
         include InstanceMethods
@@ -41,7 +41,7 @@ module HasMagicColumns
 
     module InstanceMethods
       def magic_column_names
-        magic_columns.map(&:name)
+        magic_columns.pluck(:name)
       end
 
       def magic_changes
@@ -116,14 +116,14 @@ module HasMagicColumns
 
       def create_magic_attribute(magic_column, value)
         magic_changes[magic_column.name] = [nil, value]
-        magic_attributes << MagicAttribute.create(:magic_column => magic_column, :value => value)
+        magic_attributes << MagicAttribute.create(magic_column: magic_column, value: value)
         self.touch if self.persisted?
       end
 
       def update_magic_attribute(magic_attribute, value)
         return if magic_attribute.value == value
         magic_changes[magic_attribute.magic_column.name] = [magic_attribute.value, value]
-        magic_attribute.update_attributes(:value => value)
+        magic_attribute.update_attributes(value: value)
         self.touch if self.persisted? && magic_attribute.updated_at > self.updated_at
       end
 

--- a/lib/has_magic_columns/extend.rb
+++ b/lib/has_magic_columns/extend.rb
@@ -116,6 +116,7 @@ module HasMagicColumns
       end
 
       def update_magic_attribute(magic_attribute, value)
+        return if magic_attribute.value == value
         @magic_changes[magic_attribute.magic_column.name] = [magic_attribute.value, value]
         magic_attribute.update_attributes(:value => value)
         self.touch if self.persisted? && magic_attribute.updated_at > self.updated_at

--- a/lib/has_magic_columns/version.rb
+++ b/lib/has_magic_columns/version.rb
@@ -1,3 +1,3 @@
 module HasMagicColumns
-  VERSION = "0.3.4"
+  VERSION = "0.3.5"
 end

--- a/spec/has_magic_columns/magic_columns_spec.rb
+++ b/spec/has_magic_columns/magic_columns_spec.rb
@@ -105,6 +105,23 @@ describe HasMagicColumns do
       expect { charlie.update_attributes(zip: "") }.to change { charlie.updated_at }
     end
 
+    it "tracks magic changes" do
+      charlie.magic_columns.create(name: "zip")
+      expect(charlie.magic_changes).to be_empty
+      expect(charlie.magic_changed?).to be false
+      charlie.update_attributes(zip: "12345")
+      expect(charlie.magic_changes).to eq "zip" => [nil, "12345"]
+      expect(charlie.magic_changed?).to be true
+      charlie.update_attributes(zip: "54321")
+      expect(charlie.magic_changes).to eq "zip" => ["12345", "54321"]
+      expect(charlie.magic_changed?).to be true
+      charlie.update_attributes(zip: nil)
+      expect(charlie.magic_changes).to eq "zip" => ["54321", nil]
+      expect(charlie.magic_changed?).to be true
+      expect(charlie.reload.magic_changes).to be_empty
+      expect(charlie.magic_changed?).to be false
+    end
+
     context ":check_box_multiple" do
       before { charlie.magic_columns.create(name: "multiple", datatype: "check_box_multiple") }
 


### PR DESCRIPTION
Add a helper to work like `ActiveRecord::Dirty` to pick up changes to magic columns on models using `has_magic_columns`